### PR TITLE
Fix: OggLoader.mod loads ogg files again with corrected pub.OggVorbis

### DIFF
--- a/oggloader.mod/oggloader.bmx
+++ b/oggloader.mod/oggloader.bmx
@@ -77,9 +77,10 @@ Type TAudioSampleLoaderOGG Extends TAudioSampleLoader
 		Local size=samples*2*channels
 		Local sample:TAudioSample=TAudioSample.Create( samples,freq,format )
 
-		Local err=Read_Ogg( ogg,sample.samples,size )
+		'negative amounts indicate an error, 0 = EOF, >0 = amount of bytes
+		Local bytesRead:int = Read_Ogg( ogg,sample.samples,size )
 		Read_Ogg( ogg,Null,0 )
-		If err Return
+		If bytesRead <= 0 Return
 
 		Return sample
 


### PR DESCRIPTION
Commit is a backport from the NG-modules-repository.
