### PR TITLE
Fix: Enable AppSuspended()-function on Linux-(X11)-Systems

### DIFF
--- a/glgraphics.mod/glgraphics.linux.c
+++ b/glgraphics.mod/glgraphics.linux.c
@@ -345,7 +345,7 @@ BBGLContext *bbGLGraphicsCreateGraphics( int width,int height,int depth,int hz,i
 		}
 		glXMakeCurrent(xdisplay,window,context);	
 		XIfEvent(xdisplay,&event,WaitForNotify,(XPointer)window);	     
-		XSelectInput(xdisplay,window,ResizeRedirectMask|PointerMotionMask|ButtonPressMask|ButtonReleaseMask|KeyPressMask|KeyReleaseMask);	
+		XSelectInput(xdisplay,window,ResizeRedirectMask|PointerMotionMask|ButtonPressMask|FocusChangeMask|ButtonReleaseMask|KeyPressMask|KeyReleaseMask);	
 		xwindow=window;
 		bbSetSystemWindow(xwindow);
 	}

--- a/system.mod/system.linux.c
+++ b/system.mod/system.linux.c
@@ -232,6 +232,12 @@ void bbSystemEmitOSEvent( XEvent *xevent,BBObject *source ){
 	case MotionNotify:
 		id=BBEVENT_MOUSEMOVE;
 		break;
+	case FocusIn:
+		id=BBEVENT_APPRESUME;
+		break;
+	case FocusOut:
+		id=BBEVENT_APPSUSPEND;
+		break;
 	case ClientMessage:
 		if( xevent->xclient.data.l[0]==XInternAtom( x_display,"WM_DELETE_WINDOW",True ) ){
 			id=BBEVENT_APPTERMINATE;


### PR DESCRIPTION
Before: Events for "EVENT_APPRESUME" and "EVENT_APPSUSPEND" were not generated on linux. This lead to issues with PolledInput not resetting keystates correctly.
