### PR TITLE
Fix: [Linux] Do not emit AppSuspend-event when dragging a window around

### DIFF
--- a/system.mod/system.linux.c
+++ b/system.mod/system.linux.c
@@ -236,6 +236,11 @@ void bbSystemEmitOSEvent( XEvent *xevent,BBObject *source ){
 		id=BBEVENT_APPRESUME;
 		break;
 	case FocusOut:
+		//ignore if lost focus because the window got grabbed
+		//(moving around the windowed application)
+		if( xevent->xfocus.mode == NotifyGrab || xevent->xfocus.mode == NotifyUngrab) {
+			break;
+		}
 		id=BBEVENT_APPSUSPEND;
 		break;
 	case ClientMessage:


### PR DESCRIPTION
Sorry, had to add this. Now you could move around a linux-gui-window without "appsuspend" being triggered.
