### PR TITLE
Fix: [Linux] Handle "Notify(Un)grab" for "FocusIn"-events

### DIFF
--- a/system.mod/system.linux.c
+++ b/system.mod/system.linux.c
@@ -233,14 +233,20 @@ void bbSystemEmitOSEvent( XEvent *xevent,BBObject *source ){
 		id=BBEVENT_MOUSEMOVE;
 		break;
 	case FocusIn:
+		//skip if grabbing/ungrabbing, as this is called in an
+		//"alt-tab-'out'"-situation too (FocusIn - FocusOut - FocusIn)
+		if( xevent->xfocus.mode == NotifyGrab || xevent->xfocus.mode == NotifyUngrab )
+			break;
+
 		id=BBEVENT_APPRESUME;
 		break;
 	case FocusOut:
 		//ignore if lost focus because the window got grabbed
 		//(moving around the windowed application)
-		if( xevent->xfocus.mode == NotifyGrab || xevent->xfocus.mode == NotifyUngrab) {
+		//or ungrabbed (happens while Alt-Tabbing-"in")
+		if( xevent->xfocus.mode == NotifyGrab || xevent->xfocus.mode == NotifyUngrab)
 			break;
-		}
+
 		id=BBEVENT_APPSUSPEND;
 		break;
 	case ClientMessage:

--- a/system.mod/system.linux.c
+++ b/system.mod/system.linux.c
@@ -235,8 +235,9 @@ void bbSystemEmitOSEvent( XEvent *xevent,BBObject *source ){
 	case FocusIn:
 		//skip if grabbing/ungrabbing, as this is called in an
 		//"alt-tab-'out'"-situation too (FocusIn - FocusOut - FocusIn)
-		if( xevent->xfocus.mode == NotifyGrab || xevent->xfocus.mode == NotifyUngrab )
+		if( xevent->xfocus.mode == NotifyGrab || xevent->xfocus.mode == NotifyUngrab ) {
 			break;
+		}
 
 		id=BBEVENT_APPRESUME;
 		break;
@@ -244,8 +245,9 @@ void bbSystemEmitOSEvent( XEvent *xevent,BBObject *source ){
 		//ignore if lost focus because the window got grabbed
 		//(moving around the windowed application)
 		//or ungrabbed (happens while Alt-Tabbing-"in")
-		if( xevent->xfocus.mode == NotifyGrab || xevent->xfocus.mode == NotifyUngrab)
+		if( xevent->xfocus.mode == NotifyGrab || xevent->xfocus.mode == NotifyUngrab ) {
 			break;
+		}
 
 		id=BBEVENT_APPSUSPEND;
 		break;


### PR DESCRIPTION
Fixes a problematic Event-emission "AppResume AppSuspend AppResume" when Alt-Tabbing-In to the app. This would not be visible to code just checking "AppSuspended()" as the final state is "suspended". But eventlisteners to "EVENT_APPRESUME" and "EVENT_APPSUSPEND" would get triggered (in this example this leads to flushing the keys on "app resume" too - as it emits the suspend-event).

---

Just got aware of this because a testapp scrolled a textarea with "onMouseWheel" 2 seconds after the last scroll (with input state updates happening meanwhile)  - by just hitting "print screen"-key and therefor opening up a screengrabber-tool.
